### PR TITLE
Update xsum to 2.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xsum" %}
-{% set version = "1.1.1" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,28 +7,35 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21ff547dbb64e8ddefd376f2889349c7a94fce69e7fc417fc661068b298473b1
+  sha256: e4bdab1d4b5058ad04c2ae30cc26b3610ef04959d131a60ee8e4e48f896e5129 
 
 build:
-  number: 7
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation" 
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
   host:
-    - python 
+    - python
     - pip
-    - pybind11
+    - setuptools >=64
+    - wheel
+    - pybind11 >=2.5.0
+    - versioneer >=0.29
   run:
     - python
-    - pybind11
     - numpy
 
 test:
   imports:
     - xsum
+  commands:
+    - python -c "from xsum import xsum_small; s = xsum_small(); s.add(1.0); assert s.round() == 1.0"
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/yafshar/xsum


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Updates `xsum` to `2.0.0`.

This release syncs the package with the latest upstream exact-summation updates, including new accumulator negation, conversion, and integer-division APIs, small-accumulator correctness fixes, and refreshed Python packaging metadata.

Recipe updates:
* reset build number to `0`
* require Python `>=3.10`
* add explicit PEP 517 build requirements
* keep `pybind11` as a host/build dependency only
* add a basic runtime smoke test and `pip check`